### PR TITLE
Switch to docker compose v2 in all scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ This repository will help you set up your own beam broker instance.
 
 ## Requirements
 Before starting with the installation, ensure you have the following software installed:
-- [docker with docker-compose](https://www.docker.com/)
+- [docker with docker compose](https://www.docker.com/)
 - [jq](https://stedolan.github.io/jq/)
 - [traefik](https://doc.traefik.io/traefik/) reverse proxy with external network `traefik`
 
@@ -12,7 +12,7 @@ Before starting with the installation, ensure you have the following software in
 2. Copy `.env.template` to `.env`, adapt to your needs
 3. Run `./pki-scripts/initial_vault_setup.sh` to setup your initial vault. **Important:** Note down the unseal key.
 4. Run `./pki-scripts/create_privkey_and_cert.sh broker` to create a dummy certificate for the Broker.
-5. Start manually using `docker-compose up` or use supplied [systemd unit](./beam-central.service.example) to restart upon boot.
+5. Start manually using `docker compose up` or use supplied [systemd unit](./beam-central.service.example) to restart upon boot.
 
 ## Maintenance
 A collection of common tasks then managing your own broker.

--- a/beam-central.service.example
+++ b/beam-central.service.example
@@ -9,13 +9,13 @@ Restart=always
 WorkingDirectory=/srv/docker/beam-broker
 
 # Remove old containers, images and volumes
-ExecStartPre=/usr/bin/docker-compose pull
+ExecStartPre=/usr/bin/docker compose pull
 
 # Compose up
-ExecStart=/usr/bin/docker-compose up --abort-on-container-exit
+ExecStart=/usr/bin/docker compose up --abort-on-container-exit
 
 # Compose down, remove containers and volumes
-ExecStop=/usr/bin/docker-compose down
+ExecStop=/usr/bin/docker compose down
 
 [Install]
 WantedBy=multi-user.target

--- a/pki-scripts/initial_vault_setup.sh
+++ b/pki-scripts/initial_vault_setup.sh
@@ -30,46 +30,46 @@ function check_prereqs() {
 }
 
 function init_vault() {
-     docker-compose exec -e VAULT_ADDR="http://127.0.0.1:8200" -it vault vault operator init -key-shares=1 -key-threshold=1 > "$PKI_DIR/init.tmp"
+     docker compose exec -e VAULT_ADDR="http://127.0.0.1:8200" -it vault vault operator init -key-shares=1 -key-threshold=1 > "$PKI_DIR/init.tmp"
      cat "$PKI_DIR/init.tmp" | grep "Unseal Key" > "$PKI_DIR/unseal_key.secret"
      cat "$PKI_DIR/init.tmp" | grep "Root Token" | awk '{print $4}' > "$PKI_DIR/pki.secret" 
      rm "$PKI_DIR/init.tmp"
 }
 
 function unseal_vault() {
-     docker-compose exec -e VAULT_ADDR="http://127.0.0.1:8200" vault vault operator unseal $(cat "$PKI_DIR/unseal_key.secret" | awk '{print $4}')
+     docker compose exec -e VAULT_ADDR="http://127.0.0.1:8200" vault vault operator unseal $(cat "$PKI_DIR/unseal_key.secret" | awk '{print $4}')
 }
 
 function create_root_ca() {
-     docker-compose exec -e VAULT_ADDR="http://127.0.0.1:8200" -e VAULT_TOKEN=$VAULT_TOKEN vault vault secrets enable pki
-     docker-compose exec -e VAULT_ADDR="http://127.0.0.1:8200" -e VAULT_TOKEN=$VAULT_TOKEN vault vault secrets tune -max-lease-ttl=87600h pki
-     docker-compose exec -e VAULT_ADDR="http://127.0.0.1:8200" -e VAULT_TOKEN=$VAULT_TOKEN -e PROJECT vault \
+     docker compose exec -e VAULT_ADDR="http://127.0.0.1:8200" -e VAULT_TOKEN=$VAULT_TOKEN vault vault secrets enable pki
+     docker compose exec -e VAULT_ADDR="http://127.0.0.1:8200" -e VAULT_TOKEN=$VAULT_TOKEN vault vault secrets tune -max-lease-ttl=87600h pki
+     docker compose exec -e VAULT_ADDR="http://127.0.0.1:8200" -e VAULT_TOKEN=$VAULT_TOKEN -e PROJECT vault \
 	   vault write -field=certificate pki/root/generate/internal \
           common_name="Broker-Root" \
           issuer_name="${PROJECT}-CA-Root" \
           ttl=87600h > "$PKI_DIR/${PROJECT}_root_2022_ca.crt.pem"
-     docker-compose exec -e VAULT_ADDR -e VAULT_TOKEN=$VAULT_TOKEN vault vault write pki/roles/2022-servers_root allow_any_name=true
+     docker compose exec -e VAULT_ADDR -e VAULT_TOKEN=$VAULT_TOKEN vault vault write pki/roles/2022-servers_root allow_any_name=true
      cp "$PKI_DIR/${PROJECT}_root_2022_ca.crt.pem" "$PKI_DIR/root.crt.pem"
 }
 
 function create_intermediate_ca() {
-     docker-compose exec -e VAULT_ADDR="http://127.0.0.1:8200" -e VAULT_TOKEN=$VAULT_TOKEN vault vault secrets enable -path=samply_pki pki
-     docker-compose exec -e VAULT_ADDR="http://127.0.0.1:8200" -e VAULT_TOKEN=$VAULT_TOKEN vault vault secrets tune -max-lease-ttl=43800h samply_pki
-     docker-compose exec -e VAULT_ADDR="http://127.0.0.1:8200" -e VAULT_TOKEN=$VAULT_TOKEN -e BROKER_ID -it vault \
+     docker compose exec -e VAULT_ADDR="http://127.0.0.1:8200" -e VAULT_TOKEN=$VAULT_TOKEN vault vault secrets enable -path=samply_pki pki
+     docker compose exec -e VAULT_ADDR="http://127.0.0.1:8200" -e VAULT_TOKEN=$VAULT_TOKEN vault vault secrets tune -max-lease-ttl=43800h samply_pki
+     docker compose exec -e VAULT_ADDR="http://127.0.0.1:8200" -e VAULT_TOKEN=$VAULT_TOKEN -e BROKER_ID -it vault \
 	   vault write -format=json samply_pki/intermediate/generate/internal \
           common_name="$BROKER_ID Intermediate Authority" \
           issuer_name="$BROKER_ID-intermediate" \
           | jq -r '.data.csr' > "$PKI_DIR/pki_intermediate.csr.pem"
-     docker-compose exec -e VAULT_ADDR="http://127.0.0.1:8200" -e VAULT_TOKEN=$VAULT_TOKEN -e PROJECT -it vault \
+     docker compose exec -e VAULT_ADDR="http://127.0.0.1:8200" -e VAULT_TOKEN=$VAULT_TOKEN -e PROJECT -it vault \
 	   vault write -format=json pki/root/sign-intermediate \
           issuer_ref="${PROJECT}-CA-Root" \
           csr=@pki/pki_intermediate.csr.pem \
           format=pem_bundle ttl="43800h" \
           | jq -r '.data.certificate' > "$PKI_DIR/intermediate.crt.pem"
-     docker-compose exec -e VAULT_ADDR="http://127.0.0.1:8200" -e VAULT_TOKEN=$VAULT_TOKEN vault \
+     docker compose exec -e VAULT_ADDR="http://127.0.0.1:8200" -e VAULT_TOKEN=$VAULT_TOKEN vault \
 	   vault write samply_pki/intermediate/set-signed certificate=@pki/intermediate.crt.pem
-     ISSUER=$(docker-compose exec -e VAULT_ADDR="http://127.0.0.1:8200" -e VAULT_TOKEN=$VAULT_TOKEN vault vault read -field=default samply_pki/config/issuers)
-     docker-compose exec -e VAULT_ADDR="http://127.0.0.1:8200" -e VAULT_TOKEN=$VAULT_TOKEN -e BROKER_ID -it vault \
+     ISSUER=$(docker compose exec -e VAULT_ADDR="http://127.0.0.1:8200" -e VAULT_TOKEN=$VAULT_TOKEN vault vault read -field=default samply_pki/config/issuers)
+     docker compose exec -e VAULT_ADDR="http://127.0.0.1:8200" -e VAULT_TOKEN=$VAULT_TOKEN -e BROKER_ID -it vault \
           vault write "samply_pki/roles/samply-beam-default-role" \
           issuer_ref="${ISSUER}" \
           allowed_domains="$BROKER_ID" \
@@ -80,7 +80,7 @@ function create_intermediate_ca() {
 
 function init() {
   	 echo "Starting vault for the first time"
-     docker-compose up -d vault
+     docker compose up -d vault
      
      echo "Waiting 10 seconds for vault to start"
 		 sleep 10

--- a/pki/pki.sh
+++ b/pki/pki.sh
@@ -37,23 +37,23 @@ function start() {
       docker_compose_file="../docker-compose-local.yml"
     ;;
   esac
-  docker-compose -f $docker_compose_file up -d vault
+  docker compose -f $docker_compose_file up -d vault
 }
 
 function clean() {
   rm -vf *.pem *.json
   case "$1" in
     dev)
-      docker_compose_file="../docker-compose-dev.yml"
+      docker_compose_file="../docker compose-dev.yml"
     ;;
     central)
-      docker_compose_file="../docker-compose-central.yml"
+      docker_compose_file="../docker compose-central.yml"
     ;;
     local)
-      docker_compose_file="../docker-compose-local.yml"
+      docker_compose_file="../docker compose-local.yml"
     ;;
   esac
-  docker-compose -f $docker_compose_file down
+  docker compose -f $docker_compose_file down
 }
 
 function create_root_ca() {
@@ -171,9 +171,9 @@ case "$1" in
     export VAULT_ADDR=$EXT_VAULT_ADDR
     start central
     while ! [ "$(curl -s $VAULT_ADDR/v1/sys/health | jq -r .sealed)" == "false" ]; do echo "Vault not yet ready (or sealed), waiting ..."; sleep 1; done
-    docker-compose exec vault sh -c "https_proxy=$http_proxy apk add --no-cache bash curl jq"
-    [ -e intermediate.crt.pem ] || docker-compose exec vault sh -c "VAULT_TOKEN=$VAULT_TOKEN http_proxy= HTTP_PROXY= BROKER_ID=$BROKER_ID /pki/pki.sh init"
-    [ -e dummy.priv.pem ] || docker-compose exec vault sh -c "VAULT_TOKEN=$VAULT_TOKEN http_proxy= HTTP_PROXY= BROKER_ID=$BROKER_ID /pki/pki.sh request_proxy dummy"
+    docker compose exec vault sh -c "https_proxy=$http_proxy apk add --no-cache bash curl jq"
+    [ -e intermediate.crt.pem ] || docker compose exec vault sh -c "VAULT_TOKEN=$VAULT_TOKEN http_proxy= HTTP_PROXY= BROKER_ID=$BROKER_ID /pki/pki.sh init"
+    [ -e dummy.priv.pem ] || docker compose exec vault sh -c "VAULT_TOKEN=$VAULT_TOKEN http_proxy= HTTP_PROXY= BROKER_ID=$BROKER_ID /pki/pki.sh request_proxy dummy"
     ;;
   devsetup)
     #          set -m # job control
@@ -189,12 +189,12 @@ case "$1" in
     touch ${PROXY2_ID_SHORT}.priv.pem # see https://github.com/docker/compose/issues/8305
     start dev
     while ! [ "$(curl -s $VAULT_ADDR/v1/sys/health | jq -r .sealed)" == "false" ]; do echo "Waiting ..."; sleep 0.1; done
-    docker-compose exec vault sh -c "https_proxy=$http_proxy apk add --no-cache bash curl jq"
-    docker-compose exec vault sh -c "VAULT_TOKEN=$VAULT_TOKEN http_proxy=
+    docker compose exec vault sh -c "https_proxy=$http_proxy apk add --no-cache bash curl jq"
+    docker compose exec vault sh -c "VAULT_TOKEN=$VAULT_TOKEN http_proxy=
     HTTP_PROXY= BROKER_ID=$BROKER_ID /pki/pki.sh init"
-    docker-compose exec vault sh -c "VAULT_TOKEN=$VAULT_TOKEN http_proxy= HTTP_PROXY= BROKER_ID=$BROKER_ID /pki/pki.sh request_proxy $PROXY1_ID_SHORT"
-    docker-compose exec vault sh -c "VAULT_TOKEN=$VAULT_TOKEN http_proxy= HTTP_PROXY= BROKER_ID=$BROKER_ID /pki/pki.sh request_proxy $PROXY2_ID_SHORT"
-    docker-compose exec vault sh -c "VAULT_TOKEN=$VAULT_TOKEN http_proxy= HTTP_PROXY= BROKER_ID=$BROKER_ID /pki/pki.sh request_proxy dummy"
+    docker compose exec vault sh -c "VAULT_TOKEN=$VAULT_TOKEN http_proxy= HTTP_PROXY= BROKER_ID=$BROKER_ID /pki/pki.sh request_proxy $PROXY1_ID_SHORT"
+    docker compose exec vault sh -c "VAULT_TOKEN=$VAULT_TOKEN http_proxy= HTTP_PROXY= BROKER_ID=$BROKER_ID /pki/pki.sh request_proxy $PROXY2_ID_SHORT"
+    docker compose exec vault sh -c "VAULT_TOKEN=$VAULT_TOKEN http_proxy= HTTP_PROXY= BROKER_ID=$BROKER_ID /pki/pki.sh request_proxy dummy"
     ;;
   *)
     echo "Usage: $0 start|init|setup_central|devsetup|(request_proxy [AppName])"


### PR DESCRIPTION
Docker-Compose v1 (with a dash) has now been deprecated for nearly three years. We encountered issues in following the install instruction and even more subtile errors when both versions are installed at multiple sites.