### PR TITLE
fix beam cert manager router

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -91,8 +91,7 @@ services:
       - "traefik.http.routers.cert-manager-admin.priority=101"
       - "traefik.http.routers.cert-manager-admin.entrypoints=websecure"
       - "traefik.http.routers.cert-manager-admin.tls.certresolver=letsencrypt"
-      - "traefik.http.middlewares.strip-admin.stripprefix.prefixes=/admin"
-      - "traefik.http.routers.cert-manager-admin.middlewares=oidc-auth,strip-admin"
+      - "traefik.http.routers.cert-manager-admin.middlewares=oidc-auth"
       - "traefik.http.routers.cert-manager-admin.service=cert-manager-admin"
       - "traefik.http.services.cert-manager-admin.loadbalancer.server.port=8080"
 


### PR DESCRIPTION
In the latest release beam cert manager accepts these routes directly as doing the reverse proxy rewrite lead to problems with the dioxus frontend router.