### PR TITLE
pin vault to 1.x to fix startup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ networks:
     external: true
 services:
   vault:
-    image: hashicorp/vault
+    image: hashicorp/vault:1.21
     ports:
       - "127.0.0.1:8200:8200"
     volumes:


### PR DESCRIPTION
starting with 2.x vault errors with "unable to set CAP_SETFCAP effective capability: Operation not permitted". Adding that capability did not seem to fix the issue. Also vault 2.x refuses to work with the docker auto generated volume mount without manually setting it up with the right permissons.